### PR TITLE
Replace deprecated pkg_resources with importlib.resources for future setuptools compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ LONGDESC = '''
 
 setup(
     name='zhconv',
-    version='1.4.2',
+    version='1.4.3',
     description="A simple implementation of Simplified-Traditional Chinese conversion.",
     long_description=LONGDESC,
     author='Dingyuan Wang',

--- a/zhconv/zhconv.py
+++ b/zhconv/zhconv.py
@@ -22,7 +22,7 @@ Support MediaWiki's convertion format:
 
 """
 # Only Python3 can pass the doctest here due to unicode problems.
-__version__ = '1.4.2'
+__version__ = '1.4.3'
 
 import os
 import sys


### PR DESCRIPTION
### Fixed issue #16 

This PR replaces the use of `pkg_resources.resource_stream` (deprecated since setuptools 81) with the modern `importlib.resources.files()` API.

- Future-proofs zhconv against pkg_resources removal (scheduled for 2025-11-30)
- Adds fallback to `importlib_resources` for Python < 3.9
- Merge the detached commit 0f066eb (v1.4.3) into the **master** branch
- Updated version to v1.4.4

Tested with Python 3.8–3.12.